### PR TITLE
test: increase coverage for `GnoValidatorsChecker`

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,3 @@
 @openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/
 @openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
+forge-std/=lib/forge-std/src/

--- a/test/gnosis/GnoValidatorsChecker.t.sol
+++ b/test/gnosis/GnoValidatorsChecker.t.sol
@@ -7,6 +7,7 @@ import {IGnoVault} from "../../contracts/interfaces/IGnoVault.sol";
 import {IVaultEnterExit} from "../../contracts/interfaces/IVaultEnterExit.sol";
 import {IVaultState} from "../../contracts/interfaces/IVaultState.sol";
 import {IKeeperRewards} from "../../contracts/interfaces/IKeeperRewards.sol";
+import {IValidatorsChecker} from "../../contracts/interfaces/IValidatorsChecker.sol";
 import {GnoHelpers} from "../helpers/GnoHelpers.sol";
 
 contract GnoValidatorsCheckerTest is Test, GnoHelpers {
@@ -61,6 +62,17 @@ contract GnoValidatorsCheckerTest is Test, GnoHelpers {
 
         // Get valid registry root
         validRegistryRoot = contracts.validatorsRegistry.get_deposit_root();
+    }
+
+    // Test checkValidatorsManagerSignature with an empty vault
+    function testCheckValidatorsManagerSignature_InsufficientAssets() public view {
+        // Test with empty vault
+        (uint256 blockNumber, IValidatorsChecker.Status status) =
+            validatorsChecker.checkValidatorsManagerSignature(emptyVault, validRegistryRoot, "", "");
+
+        // Verify result
+        assertEq(uint256(status), uint256(IValidatorsChecker.Status.INSUFFICIENT_ASSETS));
+        assertEq(blockNumber, block.number);
     }
 
     // Test getExitQueueCumulativeTickets and getExitQueueMissingAssets with an empty exit queue


### PR DESCRIPTION
This PR:
1. Adds `forge-std` to `remappings.txt` (so that there were no errors in Visual Studio Code )
2. Slightly increases code coverage for the [GnoValidatorsChecker](https://github.com/stakewise/v3-core/blob/ad3ee575724fbe5aea90b36e0d027c65a32adec2/contracts/validators/GnoValidatorsChecker.sol) contract

Before: 
```
contracts/validators/GnoValidatorsChecker.sol | 66.67% (4/6) | 75.00% (3/4) | 100.00% (0/0) | 66.67% (2/3)
```

After: 
```
contracts/validators/GnoValidatorsChecker.sol | 100.00% (6/6) | 100.00% (4/4) | 100.00% (0/0) | 100.00% (3/3)
```